### PR TITLE
adding abililty to specify alternate registry to download images from

### DIFF
--- a/cmd/hydrate/download.go
+++ b/cmd/hydrate/download.go
@@ -12,7 +12,7 @@ import (
 var downloadCommand = cli.Command{
 	Name:  "download",
 	Usage: "downloads an image",
-	Description: `The download command downloads an image from registry.hub.docker.com.
+	Description: `The download command downloads an image from specified registry.
 	The downloaded image is formatted according to the OCI Image Format Specification`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
@@ -34,6 +34,16 @@ var downloadCommand = cli.Command{
 			Name:  "noTarball",
 			Usage: "Do not output image as a tarball",
 		},
+		cli.StringFlag{
+			Name:  "authServerURL",
+			Value: "https://auth.docker.io",
+			Usage: "Docker AuthServerURL to use",
+		},
+		cli.StringFlag{
+			Name:  "registryServerURL",
+			Value: "https://registry.hub.docker.com",
+			Usage: "Docker Registry URL to use",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := checkArgs(context, 0, exactArgs); err != nil {
@@ -46,7 +56,8 @@ var downloadCommand = cli.Command{
 		if imageName == "" {
 			return errors.New("ERROR: No image name provided")
 		}
-
-		return imagefetcher.New(logger, context.String("outputDir"), imageName, context.String("tag"), context.Bool("noTarball")).Run()
+		imageFetcher := imagefetcher.New(logger, context.String("outputDir"), imageName, context.String("tag"), context.Bool("noTarball"))
+		imageFetcher.SetCustomRegistry(context.String("authServerURL"), context.String("registryServerURL"))
+		return imageFetcher.Run()
 	},
 }

--- a/imagefetcher/imagefetcher.go
+++ b/imagefetcher/imagefetcher.go
@@ -16,20 +16,33 @@ import (
 )
 
 type ImageFetcher struct {
-	logger    *log.Logger
-	outDir    string
-	imageName string
-	imageTag  string
-	noTarball bool
+	logger            *log.Logger
+	outDir            string
+	imageName         string
+	imageTag          string
+	noTarball         bool
+	authServerURL     string
+	registryServerURL string
 }
 
 func New(logger *log.Logger, outDir, imageName, imageTag string, noTarball bool) *ImageFetcher {
 	return &ImageFetcher{
-		logger:    logger,
-		outDir:    outDir,
-		imageName: imageName,
-		imageTag:  imageTag,
-		noTarball: noTarball,
+		logger:            logger,
+		outDir:            outDir,
+		imageName:         imageName,
+		imageTag:          imageTag,
+		noTarball:         noTarball,
+		authServerURL:     "https://auth.docker.io",
+		registryServerURL: "https://registry.hub.docker.com",
+	}
+}
+
+func (i *ImageFetcher) SetCustomRegistry(authServerURL, registryServerURL string) {
+	if len(authServerURL) > 0 {
+		i.authServerURL = authServerURL
+	}
+	if len(registryServerURL) > 0 {
+		i.registryServerURL = registryServerURL
 	}
 }
 
@@ -57,7 +70,7 @@ func (i *ImageFetcher) Run() error {
 		return err
 	}
 
-	r := registry.New("https://auth.docker.io", "https://registry.hub.docker.com", i.imageName, i.imageTag)
+	r := registry.New(i.authServerURL, i.registryServerURL, i.imageName, i.imageTag)
 	d := downloader.New(i.logger, blobDownloadDir, r)
 
 	layers, diffIds, err := d.Run()


### PR DESCRIPTION
This allows ability to use this library/cli to download images that are hosted in a private registry (not dockerhub).  https://github.com/cloudfoundry/hydrator/issues/2